### PR TITLE
add network to Platform Enum and account for fractions of a second in metadata strptime

### DIFF
--- a/slippi/game.py
+++ b/slippi/game.py
@@ -139,7 +139,7 @@ class Game(Base):
             d = json['startAt']
             if d[-1] == 'Z':
                 d = d[:-1] + '+0000'
-            date = datetime.strptime(d, '%Y-%m-%dT%H:%M:%S%z')
+            date = datetime.strptime(d, '%Y-%m-%dT%H:%M:%S.%f%z')
             try:
                 duration = 1 + json['lastFrame'] - FIRST_FRAME_INDEX
             except KeyError: duration = None
@@ -177,3 +177,4 @@ class Game(Base):
         class Platform(Enum):
             CONSOLE = 'console'
             DOLPHIN = 'dolphin'
+            NETWORK = 'network'


### PR DESCRIPTION
Had some issues with the files being created on R14(? the new version made for mirroring slippi), so I went in and fixed the issues.