### PR TITLE
Convert unknown attack actions to OTHER.

### DIFF
--- a/slippi/event.py
+++ b/slippi/event.py
@@ -334,6 +334,10 @@ class Attack(IntEnum):
     LEDGE_ATTACK_SLOW = 61
     LEDGE_ATTACK = 62
 
+    @classmethod
+    def _missing_(cls, _):
+      return cls.OTHER
+
 
 class Triggers(Base):
     __slots__ = 'logical', 'physical'


### PR DESCRIPTION
Fix for #4. Ideally all of the attack actions will be mapped out, but this is still good to have just in case.