### PR TITLE
Add partial parsing of replay files

### DIFF
--- a/slippi/game.py
+++ b/slippi/game.py
@@ -14,6 +14,9 @@ class Game(Base):
     """Replay data from a game of Super Smash Brothers Melee."""
 
     def __init__(self, path, partial_parse=False):
+        """Reads data from the Slippi (.slp) replay file at `path`.
+        If `partial_parse` is `True`, only metadata and Game Start/End events will be parsed for a speedup.
+        """
 
         self.metadata = None
         """:py:class:`Metadata`: Miscellaneous data relevant to the game but not directly provided by Melee"""
@@ -32,7 +35,7 @@ class Game(Base):
         if partial_parse:
             self._parse_file_partial(path)
         else:
-        self._parse_file(path)
+            self._parse_file(path)
 
     def _parse_event_payloads(self, stream):
         (code, payload_size) = unpack('BB', stream)
@@ -121,7 +124,7 @@ class Game(Base):
                     self.end = event
         except EofException:
             pass
-
+    
     def _parse_file_partial(self, path):
         """Parses only the metadata, start and end events for the .slp file at `path`. Called automatically by our constructor."""
 

--- a/slippi/game.py
+++ b/slippi/game.py
@@ -13,8 +13,7 @@ FIRST_FRAME_INDEX = -123
 class Game(Base):
     """Replay data from a game of Super Smash Brothers Melee."""
 
-    def __init__(self, path):
-        """Reads data from the Slippi (.slp) replay file at `path`."""
+    def __init__(self, path, partial_parse=False):
 
         self.metadata = None
         """:py:class:`Metadata`: Miscellaneous data relevant to the game but not directly provided by Melee"""
@@ -30,6 +29,9 @@ class Game(Base):
 
         self._out_of_order = False
 
+        if partial_parse:
+            self._parse_file_partial(path)
+        else:
         self._parse_file(path)
 
     def _parse_event_payloads(self, stream):
@@ -120,6 +122,13 @@ class Game(Base):
         except EofException:
             pass
 
+    def _parse_file_partial(self, path):
+        """Parses only the metadata, start and end events for the .slp file at `path`. Called automatically by our constructor."""
+
+        with open(path, 'rb') as f:
+            json = ubjson.load(f)
+
+        self.metadata = self.Metadata._parse(json['metadata'])
     def __repr__(self):
         return '%s(metadata=%s, start=%s, end=%s, frames=[...])' % \
             (self.__class__.__name__, self.metadata, self.start, self.end)

--- a/test/replays.py
+++ b/test/replays.py
@@ -19,6 +19,12 @@ class TestGame(unittest.TestCase):
     def _game(self, name):
         return Game(os.path.join(os.path.dirname(__file__), 'replays', name+'.slp'))
 
+    def _game_partial(self, name):
+        return Game(
+            os.path.join(os.path.dirname(__file__), 'replays', name+'.slp'),
+            partial_parse=True
+        )
+
     def _stick_seq(self, game):
         pass
 
@@ -85,6 +91,24 @@ class TestGame(unittest.TestCase):
 
         self.assertEqual(game.metadata.duration, len(game.frames))
 
+    def test_game_partial_parse(self):
+        game = self._game_partial('game')
+
+        self.assertEqual(game.metadata, Game.Metadata._parse({
+            'startAt': '2018-06-22T07:52:59Z',
+            'lastFrame': 5085,
+            'playedOn': 'dolphin',
+            'players': {
+                '0': {'characters': {InGameCharacter.MARTH: 5209}},
+                '1': {'characters': {InGameCharacter.FOX: 5209}}}}))
+        self.assertEqual(game.metadata, Game.Metadata(
+            date=datetime.datetime(2018, 6, 22, 7, 52, 59, 0, datetime.timezone.utc),
+            duration=5209,
+            platform=Game.Metadata.Platform.DOLPHIN,
+            players=(
+                Game.Metadata.Player({InGameCharacter.MARTH: 5209}),
+                Game.Metadata.Player({InGameCharacter.FOX: 5209}),
+                None, None)))
     def test_ics(self):
         game = self._game('ics')
         self.assertEqual(game.metadata.players[0].characters, {

--- a/test/replays.py
+++ b/test/replays.py
@@ -18,7 +18,7 @@ def norm(f):
 class TestGame(unittest.TestCase):
     def _game(self, name):
         return Game(os.path.join(os.path.dirname(__file__), 'replays', name+'.slp'))
-
+    
     def _game_partial(self, name):
         return Game(
             os.path.join(os.path.dirname(__file__), 'replays', name+'.slp'),
@@ -109,6 +109,19 @@ class TestGame(unittest.TestCase):
                 Game.Metadata.Player({InGameCharacter.MARTH: 5209}),
                 Game.Metadata.Player({InGameCharacter.FOX: 5209}),
                 None, None)))
+
+        self.assertEqual(game.start, Start(
+            is_teams=False,
+            random_seed=3803194226,
+            slippi=Start.Slippi(Start.Slippi.Version(1,0,0,0)),
+            stage=Stage.YOSHIS_STORY,
+            players=(
+                Start.Player(character=CSSCharacter.MARTH, type=Start.Player.Type.HUMAN, stocks=4, costume=3, team=None, ucf=Start.Player.UCF(False, False)),
+                Start.Player(character=CSSCharacter.FOX, type=Start.Player.Type.CPU, stocks=4, costume=0, team=None, ucf=Start.Player.UCF(False, False)),
+                None, None)))
+
+        self.assertEqual(game.end, End(End.Method.CONCLUSIVE))
+
     def test_ics(self):
         game = self._game('ics')
         self.assertEqual(game.metadata.players[0].characters, {


### PR DESCRIPTION
Hey, thanks for the great library.

This PR modifies `slippi.game.Game` to add the ability to parse only the metadata, game start and game end events.  This speeds up parsing in situations where you may want to retrieve information about the overall game (characters, ports, stage, etc), but have no need to inspect the actual gameplay frames themselves.  
My personal use-case is for loading a ton of replays into a database so that I can later search them by matchup, stage, etc. Parsing all the gameplay frames adds some significant processing time that this PR now allows the user to avoid if desired (see performance comparison below).

### Changes

1. Added new optional argument, `partial_parsing=False` to the constructor of `slippi.game.Game`
2. Added new method, `_parse_file_partial` to `slippi.game.Game`
3. Added new test, `test_game_partial_parse`, and new helper method, `_game_partial` to `test/replays.py`

### Performance Comparison

A quick check from `ipython %timeit`:  

```ipython
In [1]: from slippi.game import Game                                                                                                                                

In [2]: %timeit Game('./test/replays/game.slp')                                                                                                                     
316 ms ± 2.92 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [3]: %timeit Game('./test/replays/game.slp', partial_parse=True)                                                                                                 
44.4 ms ± 254 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

### Notes

All tests are passing.  

Based on something Fizzi said on discord, it may be possible to extract the game end event without iterating through the raw stream to get to it.  If so this would add some additional speedup as we could stop parsing after the game start event.  Possible future improvement.

Thanks & let me know of any input.