### PR TITLE
Fix index error

### DIFF
--- a/slippi/util.py
+++ b/slippi/util.py
@@ -12,7 +12,7 @@ def _indent(s):
 
 def _format_collection(coll, delim_open, delim_close):
     elements = [_format(x) for x in coll]
-    if '\n' in elements[0]:
+    if len(elements) > 0 and '\n' in elements[0]:
         return delim_open + '\n' + ',\n'.join(_indent(e) for e in elements) + delim_close
     else:
         return delim_open + ', '.join(elements) + delim_close

--- a/slippi/util.py
+++ b/slippi/util.py
@@ -12,7 +12,7 @@ def _indent(s):
 
 def _format_collection(coll, delim_open, delim_close):
     elements = [_format(x) for x in coll]
-    if len(elements) > 0 and '\n' in elements[0]:
+    if elements and '\n' in elements[0]:
         return delim_open + '\n' + ',\n'.join(_indent(e) for e in elements) + delim_close
     else:
         return delim_open + ', '.join(elements) + delim_close


### PR DESCRIPTION
Make _format_collection compatible with empty collections

- When loading up py-slippi and loading a .slp, I hit an `IndexError` when trying to view `game.frames`
- Digging into what was happening with pdb, I found that `_format_collection` was being called where `coll` was an empty tuple
- After adding this change, was able to successfully view `game.frames`