### PR TITLE
Added support for single updates from Dolphin

### DIFF
--- a/slippi/event.py
+++ b/slippi/event.py
@@ -268,7 +268,7 @@ class Frame(Base):
             @property
             def post(self):
                 """:py:class:`Post`: Post-frame update data"""
-                if self._post and not isinstance(self._ppst, self.Post):
+                if self._post and not isinstance(self._post, self.Post):
                     self._post = self.Post._parse(self._post)
                 return self._post
 

--- a/slippi/event.py
+++ b/slippi/event.py
@@ -261,14 +261,14 @@ class Frame(Base):
             @property
             def pre(self):
                 """:py:class:`Pre`: Pre-frame update data"""
-                if not (isinstance(self._pre, self.Pre) or self._pre is None):
+                if self._pre and not isinstance(self._pre, self.Pre):
                     self._pre = self.Pre._parse(self._pre)
                 return self._pre
 
             @property
             def post(self):
                 """:py:class:`Post`: Post-frame update data"""
-                if not (isinstance(self._post, self.Post) or self._post is None):
+                if self._post and not isinstance(self._ppst, self.Post):
                     self._post = self.Post._parse(self._post)
                 return self._post
 

--- a/slippi/event.py
+++ b/slippi/event.py
@@ -261,14 +261,14 @@ class Frame(Base):
             @property
             def pre(self):
                 """:py:class:`Pre`: Pre-frame update data"""
-                if not isinstance(self._pre, self.Pre):
+                if not (isinstance(self._pre, self.Pre) or self._pre is None):
                     self._pre = self.Pre._parse(self._pre)
                 return self._pre
 
             @property
             def post(self):
-                """:py:class:`Post`: Pre-frame update data"""
-                if not isinstance(self._post, self.Post):
+                """:py:class:`Post`: Post-frame update data"""
+                if not (isinstance(self._post, self.Post) or self._post is None):
                     self._post = self.Post._parse(self._post)
                 return self._post
 

--- a/slippi/parse.py
+++ b/slippi/parse.py
@@ -63,8 +63,15 @@ def _parse_event(event_stream, payload_sizes):
     try: base_pos = event_stream.tell() if event_stream.seekable() else None
     except AttributeError: base_pos = None
 
-    try: size = payload_sizes[code]
-    except KeyError: raise ValueError('unexpected event type: 0x%02x' % code)
+    if code in payload_sizes:
+        size = payload_sizes[code]
+    else:
+        updated_size, (code, ) = code, unpack('B', event_stream)
+        try:
+            payload_sizes[code] = updated_size
+            size = payload_sizes[code]
+        except KeyError:
+            raise ValueError('unexpected event type: 0x%02x' % code)
 
     stream = io.BytesIO(event_stream.read(size))
 
@@ -116,7 +123,7 @@ def _parse_events(stream, payload_sizes, total_size, handlers):
     event = None
 
     # `total_size` will be zero for in-progress replays
-    while (total_size == 0 or bytes_read < total_size) and event != ParseEvent.END:
+    while ((total_size == 0 and stream.tell() < stream.getbuffer().nbytes) or bytes_read < total_size) and event != ParseEvent.END:
         (b, event) = _parse_event(stream, payload_sizes)
         bytes_read += b
         if isinstance(event, Start):


### PR DESCRIPTION
Alfred Dolphin sends Slippi data over the network and is fed to Slippi. Unfortunately py-slippi doesn't support two things. 1: Pre and Post are always expected to be togther in a Frame, let the Frame support either or if they don't arrive or arrive late (Frame 1 ->Pre, Frame 1 ->Post). 2: Payload sizes are being attached, update the default paylkoad sizes if for some reason it has changed between meta and the network send.