### PR TITLE
correct github url in sphinx documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ html_theme_options = {
     'description': 'Python parser for SSBM replay files',
     'fixed_sidebar': True,
     'github_button': True,
-    'github_repo': "https://github.com/hohav/py-slippi",
+    'github_repo': "py-slippi",
     'github_user': "hohav",
 }
 


### PR DESCRIPTION
https://py-slippi.readthedocs.io/en/latest/index.html
right now the "watch" link is broken: https://github.com/hohav/https://github.com/hohav/py-slippi

before:
<img width="541" alt="image" src="https://user-images.githubusercontent.com/5882512/113087491-54044a80-91a9-11eb-9490-bba51cb02c25.png">

after:
<img width="678" alt="image" src="https://user-images.githubusercontent.com/5882512/113093276-350bb580-91b5-11eb-9249-05c1e63ec3fc.png">

just for future reference, to build the documentation on osx:
```
brew install sphinx-doc
brew link sphinx-doc --force
python3 -m venv venv
source venv/bin/activate
pip install sphinx_autodoc_typehints
git clone ...
cd docs
make html
```