### PR TITLE
explicit imports from .util instead of wildcard/*

### DIFF
--- a/slippi/event.py
+++ b/slippi/event.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Optional, Sequence, Tuple, Union
 
 from . import id as sid
-from .util import *
+from .util import Base, IntEnum, IntFlag, unpack, PORTS, try_enum, Enum
 
 # The first frame of the game is indexed -123, counting up to zero (which is when the word "GO" appears). But since players actually get control before frame zero (!!!), we need to record these frames.
 FIRST_FRAME_INDEX = -123

--- a/slippi/game.py
+++ b/slippi/game.py
@@ -5,7 +5,7 @@ from typing import BinaryIO, List, Optional, Union
 from .event import FIRST_FRAME_INDEX, End, Frame, Start
 from .metadata import Metadata
 from .parse import ParseEvent, parse
-from .util import *
+from .util import Base
 
 
 class Game(Base):

--- a/slippi/id.py
+++ b/slippi/id.py
@@ -1,6 +1,6 @@
 # These IDs (and other very useful info for this project) came from the SSBM Data Sheet: https://docs.google.com/spreadsheets/d/1JX2w-r2fuvWuNgGb6D3Cs4wHQKLFegZe2jhbBuIhCG8
 
-from .util import *
+from .util import IntEnum
 
 
 class ActionState(IntEnum):

--- a/slippi/metadata.py
+++ b/slippi/metadata.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional, Tuple
 
 from . import event as evt
 from . import id as sid
-from .util import *
+from .util import Base, Enum, PORTS
 
 
 class Metadata(Base):

--- a/slippi/parse.py
+++ b/slippi/parse.py
@@ -8,7 +8,7 @@ import ubjson
 from .event import End, EventType, Frame, Start
 from .log import log
 from .metadata import Metadata
-from .util import *
+from .util import Enum, expect_bytes, unpack
 
 
 class ParseEvent(Enum):


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0008/#imports

> Wildcard imports (from <module> import *) should be avoided, as they make it unclear which names are present in the namespace