### PR TITLE
Update .readthedocs.yml to reflect Python 3.7 requirement

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,5 +2,5 @@ build:
   image: latest
 formats: []
 python:
-  version: 3.6
+  version: 3.7
 requirements_file: requirements.txt


### PR DESCRIPTION
https://github.com/hohav/py-slippi/commit/134b5680c6518228bb449689da5b2e9e9d394c80

already reflected in README.rst and setup.py