### PR TITLE
Optionally skip frame parsing with the 'skip_frames' option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,12 @@ py-slippi supports both event-based and object-based parsing. Object-based parsi
 
 Frame data is elided when you print games, but you can inspect a sample frame with e.g. :code:`game.frames[0]`.
 
+**Optionally skip frame parsing for a signficant speedup**::
+
+    >>> from slippi import Game
+    >>> Game('test/replays/game.slp', skip_frames=True)
+
+
 **Event-driven API**::
 
     >>> from slippi.parse import parse

--- a/slippi/game.py
+++ b/slippi/game.py
@@ -17,7 +17,7 @@ class Game(Base):
     metadata: Optional[Metadata] #: Miscellaneous data not directly provided by Melee
     metadata_raw: Optional[dict] #: Raw JSON metadata, for debugging and forward-compatibility
 
-    def __init__(self, input: Union[BinaryIO, str, os.PathLike]):
+    def __init__(self, input: Union[BinaryIO, str, os.PathLike], skip_frames=False):
         """Parse a Slippi replay.
 
         :param input: replay file object or path"""
@@ -33,7 +33,7 @@ class Game(Base):
             ParseEvent.FRAME: self._add_frame,
             ParseEvent.END: lambda x: setattr(self, 'end', x),
             ParseEvent.METADATA: lambda x: setattr(self, 'metadata', x),
-            ParseEvent.METADATA_RAW: lambda x: setattr(self, 'metadata_raw', x)})
+            ParseEvent.METADATA_RAW: lambda x: setattr(self, 'metadata_raw', x)}, skip_frames)
 
     def _add_frame(self, f):
         idx = f.index - FIRST_FRAME_INDEX

--- a/slippi/parse.py
+++ b/slippi/parse.py
@@ -115,7 +115,7 @@ def _parse_event(event_stream, payload_sizes):
         raise ParseError(str(e), pos = base_pos + stream.tell() if base_pos else None)
 
 
-def _parse_events(stream, payload_sizes, total_size, handlers):
+def _parse_events(stream, payload_sizes, total_size, handlers, skip_frames):
     current_frame = None
     bytes_read = 0
     event = None
@@ -133,6 +133,11 @@ def _parse_events(stream, payload_sizes, total_size, handlers):
             if handler:
                 handler(event)
         elif isinstance(event, Frame.Event):
+            if skip_frames: 
+                skip = total_size - bytes_read - payload_sizes[EventType.GAME_END.value] - 1
+                stream.seek(skip, os.SEEK_CUR)
+                bytes_read += skip
+                continue
             # Accumulate all events for a single frame into a single `Frame` object.
 
             # We can't use Frame Bookend events to detect end-of-frame,
@@ -167,8 +172,12 @@ def _parse_events(stream, payload_sizes, total_size, handlers):
             elif event.type is Frame.Event.Type.ITEM:
                 current_frame.items.append(Frame.Item._parse(event.data))
             elif event.type is Frame.Event.Type.START:
+                #print(event)
+                #print("total_size: {} bytes_read: {}".format(total_size, bytes_read))
                 current_frame.start = Frame.Start._parse(event.data)
             elif event.type is Frame.Event.Type.END:
+                #print(event)
+                #print("total_size: {} bytes_read: {}".format(total_size, bytes_read))
                 current_frame.end = Frame.End._parse(event.data)
             else:
                 raise Exception('unknown frame data type: %s' % event.data)
@@ -180,7 +189,7 @@ def _parse_events(stream, payload_sizes, total_size, handlers):
             handler(current_frame)
 
 
-def _parse(stream, handlers):
+def _parse(stream, handlers, skip_frames):
     # For efficiency, don't send the whole file through ubjson.
     # Instead, assume `raw` is the first element. This is brittle and
     # ugly, but it's what the official parser does so it should be OK.
@@ -188,7 +197,7 @@ def _parse(stream, handlers):
     (length,) = unpack('l', stream)
 
     (bytes_read, payload_sizes) = _parse_event_payloads(stream)
-    _parse_events(stream, payload_sizes, length - bytes_read, handlers)
+    _parse_events(stream, payload_sizes, length - bytes_read, handlers, skip_frames)
 
     expect_bytes(b'U\x08metadata', stream)
 
@@ -205,11 +214,11 @@ def _parse(stream, handlers):
     expect_bytes(b'}', stream)
 
 
-def _parse_try(input: BinaryIO, handlers):
+def _parse_try(input: BinaryIO, handlers, skip_frames):
     """Wrap parsing exceptions with additional information."""
 
     try:
-        _parse(input, handlers)
+        _parse(input, handlers, skip_frames)
     except Exception as e:
         e = e if isinstance(e, ParseError) else ParseError(str(e))
 
@@ -226,20 +235,21 @@ def _parse_try(input: BinaryIO, handlers):
         raise e
 
 
-def _parse_open(input: os.PathLike, handlers) -> None:
+def _parse_open(input: os.PathLike, handlers, skip_frames) -> None:
     with open(input, 'rb') as f:
-        _parse_try(f, handlers)
+        _parse_try(f, handlers, skip_frames)
 
 
-def parse(input: Union[BinaryIO, str, os.PathLike], handlers: Dict[ParseEvent, Callable[..., None]]) -> None:
+def parse(input: Union[BinaryIO, str, os.PathLike], handlers: Dict[ParseEvent, Callable[..., None]], skip_frames: bool) -> None:
     """Parse a Slippi replay.
 
     :param input: replay file object or path
-    :param handlers: dict of parse event keys to handler functions. Each event will be passed to the corresponding handler as it occurs."""
+    :param handlers: dict of parse event keys to handler functions. Each event will be passed to the corresponding handler as it occurs.
+    :param skip_frames: whether to skip frames for parsing.""" 
 
     if isinstance(input, str):
-        _parse_open(pathlib.Path(input), handlers)
+        _parse_open(pathlib.Path(input), handlers, skip_frames)
     elif isinstance(input, os.PathLike):
-        _parse_open(input, handlers)
+        _parse_open(input, handlers, skip_frames)
     else:
-        _parse_try(input, handlers)
+        _parse_try(input, handlers, skip_frames)

--- a/slippi/parse.py
+++ b/slippi/parse.py
@@ -172,12 +172,8 @@ def _parse_events(stream, payload_sizes, total_size, handlers, skip_frames):
             elif event.type is Frame.Event.Type.ITEM:
                 current_frame.items.append(Frame.Item._parse(event.data))
             elif event.type is Frame.Event.Type.START:
-                #print(event)
-                #print("total_size: {} bytes_read: {}".format(total_size, bytes_read))
                 current_frame.start = Frame.Start._parse(event.data)
             elif event.type is Frame.Event.Type.END:
-                #print(event)
-                #print("total_size: {} bytes_read: {}".format(total_size, bytes_read))
                 current_frame.end = Frame.End._parse(event.data)
             else:
                 raise Exception('unknown frame data type: %s' % event.data)
@@ -240,7 +236,7 @@ def _parse_open(input: os.PathLike, handlers, skip_frames) -> None:
         _parse_try(f, handlers, skip_frames)
 
 
-def parse(input: Union[BinaryIO, str, os.PathLike], handlers: Dict[ParseEvent, Callable[..., None]], skip_frames: bool) -> None:
+def parse(input: Union[BinaryIO, str, os.PathLike], handlers: Dict[ParseEvent, Callable[..., None]], skip_frames = False) -> None:
     """Parse a Slippi replay.
 
     :param input: replay file object or path

--- a/test/replays.py
+++ b/test/replays.py
@@ -112,6 +112,40 @@ class TestGame(unittest.TestCase):
 
         self.assertEqual(game.metadata.duration, len(game.frames))
 
+    def test_game_skip_frames(self):
+        game = Game(path('game'), skip_frames=True)
+
+        self.assertEqual(game.metadata, Metadata._parse({
+            'startAt': '2018-06-22T07:52:59Z',
+            'lastFrame': 5085,
+            'playedOn': 'dolphin',
+            'players': {
+                '0': {'characters': {InGameCharacter.MARTH: 5209}},
+                '1': {'characters': {InGameCharacter.FOX: 5209}}}}))
+        self.assertEqual(game.metadata, Metadata(
+            date=datetime.datetime(2018, 6, 22, 7, 52, 59, 0, datetime.timezone.utc),
+            duration=5209,
+            platform=Metadata.Platform.DOLPHIN,
+            players=(
+                Metadata.Player({InGameCharacter.MARTH: 5209}),
+                Metadata.Player({InGameCharacter.FOX: 5209}),
+                None, None)))
+
+        self.assertEqual(game.start, Start(
+            is_teams=False,
+            random_seed=3803194226,
+            slippi=Start.Slippi(Start.Slippi.Version(1,0,0,0)),
+            stage=Stage.YOSHIS_STORY,
+            players=(
+                Start.Player(character=CSSCharacter.MARTH, type=Start.Player.Type.HUMAN, stocks=4, costume=3, team=None, ucf=Start.Player.UCF(False, False)),
+                Start.Player(character=CSSCharacter.FOX, type=Start.Player.Type.CPU, stocks=4, costume=0, team=None, ucf=Start.Player.UCF(False, False)),
+                None, None)))
+
+        self.assertEqual(game.end, End(End.Method.CONCLUSIVE))
+
+        self.assertFalse(game.frames)
+
+
     def test_ics(self):
         game = self._game('ics')
         self.assertEqual(game.metadata.players[0].characters, {


### PR DESCRIPTION
This PR introduces the optional skip_frame option to the Game constructor (similar to https://github.com/hohav/peppi). This is a noop for all existing callers.

This implementation requires a seekable stream, but again this only impacts callers passing the new option.

Profiling on a sample of 187 replays: 
```
original:
289730206 function calls (289729400 primitive calls) in 234.178 seconds
w/ skip_frames:
185392 function calls (184586 primitive calls) in 0.240 seconds
```