### PR TITLE
Don't use root logger

### DIFF
--- a/slippi/log.py
+++ b/slippi/log.py
@@ -23,4 +23,4 @@ logging.setLogRecordFactory(record_factory)
 logging.basicConfig(
     level=os.environ.get('LOG_LEVEL', 'WARNING').upper(),
     format="%(levelname_colored)s: %(message)s")
-log = logging.getLogger()
+log = logging.getLogger(__name__)


### PR DESCRIPTION
Python documentation [recommends against](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library) logging to the root logger. This changes logging to `slippi.log` instead. (You could also change the logger to `slippi` or something else; `__name__` is just the most commonplace).