### PR TITLE
Fix repr of IntFlag enums (issue 47)

### DIFF
--- a/slippi/util.py
+++ b/slippi/util.py
@@ -90,9 +90,8 @@ class IntEnum(enum.IntEnum):
 
 class IntFlag(enum.IntFlag):
     def __repr__(self):
-        members, _ = enum._decompose(self.__class__, self._value_)
-        return '%s:%s' % (bin(self._value_), '|'.join([str(m._name_ or m._value_) for m in members]))
-
+        members = (name for name, val in self.__class__.__members__.items() if self & val)
+        return '%s:%s' % (bin(self._value_), '|'.join(members))
 
 class EOFError(IOError):
     def __init__(self):


### PR DESCRIPTION
The enum._decompose method has been removed in newer versions of Python (at least >=3.11). The name indicates that it was private and should not have been used in the first place. The new implementation uses only documented public methods of the enum library. The repr format should be the exact same.